### PR TITLE
Remove stale waker references

### DIFF
--- a/lib/celluloid/io/mailbox.rb
+++ b/lib/celluloid/io/mailbox.rb
@@ -1,8 +1,8 @@
 module Celluloid
   module IO
-    # An alternative implementation of Celluloid::Mailbox using Wakers
+    # An alternative implementation of Celluloid::Mailbox using Reactor
     class Mailbox < Celluloid::Mailbox
-      attr_reader :reactor, :waker
+      attr_reader :reactor
 
       def initialize
         @messages = []

--- a/lib/celluloid/io/reactor.rb
+++ b/lib/celluloid/io/reactor.rb
@@ -41,8 +41,7 @@ module Celluloid
         @selector.wakeup
       end
       
-      # Run the reactor, waiting for events, and calling the given block if
-      # the reactor is awoken by the waker
+      # Run the reactor, waiting for events or wakeup signal
       def run_once(timeout = nil)
         @selector.select_each(timeout) do |monitor|
           monitor.value.resume


### PR DESCRIPTION
Since reactor was reimplemented with nio4r f1584719c0a14ca4de33a78ff4200ef8b109aa68 there is no need for stale waker references.
