### PR TITLE
Fix build status and add dependency status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Celluloid::IO
 =============
-[![Build Status](http://travis-ci.org/tarcieri/celluloid-io.png)](http://travis-ci.org/tarcieri/celluloid-io)
+[![Build Status](https://secure.travis-ci.org/tarcieri/celluloid-io.png)](http://travis-ci.org/tarcieri/celluloid-io)
+[![Dependency Status](https://gemnasium.com/tarcieri/celluloid-io.png)](https://gemnasium.com/tarcieri/celluloid-io)
 
 You don't have to choose between threaded and evented IO! Celluloid::IO
 provides a simple and easy way to wait for IO events inside of a Celluloid


### PR DESCRIPTION
The Travis CI status image should be served up over SSL to avoid strange GitHub caching issues.
