### PR TITLE
Fix writable vs. writeable spelling.

### DIFF
--- a/lib/celluloid/io.rb
+++ b/lib/celluloid/io.rb
@@ -20,7 +20,7 @@ module Celluloid
 
     extend Forwardable
 
-    # Wait for the given IO object to become readable/writeable
-    def_delegators 'current_actor.mailbox.reactor', :wait_readable, :wait_writeable
+    # Wait for the given IO object to become readable/writable
+    def_delegators 'current_actor.mailbox.reactor', :wait_readable, :wait_writable
   end
 end

--- a/lib/celluloid/io/reactor.rb
+++ b/lib/celluloid/io/reactor.rb
@@ -21,8 +21,8 @@ module Celluloid
         wait io, :r
       end
 
-      # Wait for the given IO object to become writeable
-      def wait_writeable(io)
+      # Wait for the given IO object to become writable
+      def wait_writable(io)
         wait io, :w
       end
 


### PR DESCRIPTION
Fixes some NoMethodError exceptions I got when using TCPSocket.
