### PR TITLE
Add wrap_socket method to the TCPSocket class.

### DIFF
--- a/lib/celluloid/io/tcp_socket.rb
+++ b/lib/celluloid/io/tcp_socket.rb
@@ -29,6 +29,12 @@ module Celluloid
       def to_io
         @socket
       end
+
+      # Pass the Ruby TCPSocket to the given block and replace it with the
+      # return value of the block. (i.e. to create OpenSSL sockets)
+      def wrap_socket
+        @socket = yield(@socket)
+      end
     end
   end
 end


### PR DESCRIPTION
This feature would be nice to have to be able to handle stuff like ssl sockets. Not sure if you like the name and how it works.

``` ruby
class Test
  include Celluloid::IO

  def initialize(host, port)
    @socket = ::Celluloid::IO::TCPSocket.new(host, port)
  end

  def start_ssl(ssl_context)
    @socket.wrap_socket do |socket|
      OpenSSL::SSL::SSLSocket.new(socket, ssl_context).tap do |s|
        s.sync_close = true
        s.connect
      end
    end
  end
```
