### PR TITLE
Handle OpenSSL SSLSocket and SSLServer types in Reactor#wait.

### DIFF
--- a/lib/celluloid/io/reactor.rb
+++ b/lib/celluloid/io/reactor.rb
@@ -29,7 +29,7 @@ module Celluloid
       # Wait for the given IO operation to complete
       def wait(io, set)
         # zomg ugly type conversion :(
-        unless io.is_a?(::IO)
+        unless io.is_a?(::IO) or io.is_a?(::OpenSSL::SSL::SSLSocket) or io.is_a?(::OpenSSL::SSL::SSLServer)
           if io.respond_to? :to_io
             io = io.to_io
           elsif ::IO.respond_to? :try_convert


### PR DESCRIPTION
This diff is needed to be able to use openssl sockets. Ugly but it works for me.
