### PR TITLE
Filter CNAME results from the resolver answer.

### DIFF
--- a/lib/celluloid/io/dns_resolver.rb
+++ b/lib/celluloid/io/dns_resolver.rb
@@ -68,7 +68,10 @@ module Celluloid
         response = Resolv::DNS::Message.decode(data)
         
         addrs = []
-        response.each_answer { |name, ttl, value| addrs << value.address }
+        # The answer might include IN::CNAME entries so filters them out
+        # to include IN::A & IN::AAAA entries only.
+        response.each_answer { |name, ttl, value| addrs << (value.respond_to?(:address) ? value.address : nil) }
+        addrs.compact!
         
         return if addrs.empty?
         return addrs.first if addrs.size == 1

--- a/spec/celluloid/io/dns_resolver_spec.rb
+++ b/spec/celluloid/io/dns_resolver_spec.rb
@@ -5,4 +5,22 @@ describe Celluloid::IO::DNSResolver do
     resolver = Celluloid::IO::DNSResolver.new
     resolver.resolve("celluloid.io").should == Resolv::IPv4.create("207.97.227.245")
   end
+
+  it "resolves CNAME responses" do
+    resolver = Celluloid::IO::DNSResolver.new
+    results = resolver.resolve("www.google.com")
+    if results.is_a?(Array)
+      results.all? {|i| i.is_a?(Resolv::IPv4) }.should be_true
+    else
+      results.is_a?(Resolv::IPv4).should be_true
+    end
+    # www.yahoo.com will be resolved randomly whether multiple or
+    # single entry.
+    results = resolver.resolve("www.yahoo.com")
+    if results.is_a?(Array)
+      results.all? {|i| i.is_a?(Resolv::IPv4) }.should be_true
+    else
+      results.is_a?(Resolv::IPv4).should be_true
+    end
+  end
 end


### PR DESCRIPTION
Celluloid::IO::DNSResolver got error when the the answer includes CNAME. This change is for fixing it.
