### PR TITLE
Updated TCPSocket#read to work with nil length

### DIFF
--- a/spec/celluloid/io/tcp_socket_spec.rb
+++ b/spec/celluloid/io/tcp_socket_spec.rb
@@ -24,6 +24,20 @@ describe Celluloid::IO::TCPSocket do
       end
     end
 
+    it "read complete payload when nil size is given to #read" do
+        with_connected_sockets do |subject, peer|
+        peer << payload
+        within_io_actor { subject.read(nil) }.should eq payload
+      end
+    end
+
+    it "read complete payload when no size is given to #read" do
+        with_connected_sockets do |subject, peer|
+        peer << payload
+        within_io_actor { subject.read }.should eq payload
+      end
+    end
+
     it "reads data" do
       with_connected_sockets do |subject, peer|
         peer << payload


### PR DESCRIPTION
According to the IO classes, a read method should read the
input to the end when a length of nil, or no length is supplied.
Celluloid::IO::TCPSocket could not handle this case and crashed.
This commit adds behaviour that will read the input until no
more input is available. A spec was added to test this as well
