### PR TITLE
Bump celluloid version in gemspec

### DIFF
--- a/celluloid-io.gemspec
+++ b/celluloid-io.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Celluloid::IO::VERSION
 
-  gem.add_dependency 'celluloid', '~> 0.10.0'
+  gem.add_dependency 'celluloid', '~> 0.11.0'
   gem.add_dependency 'nio4r',     '>= 0.3.1'
   
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Optimistic version constraint in the gemspec doesn't jive w/ celluloid HEAD after v0.11.0 release.
