### PR TITLE
Fix #read and #readpartial to return ASCII-8BIT string

### DIFF
--- a/lib/celluloid/io/common_methods.rb
+++ b/lib/celluloid/io/common_methods.rb
@@ -63,7 +63,7 @@ module Celluloid
       end
 
       def read(length = nil, buffer = nil)
-        buffer ||= ''
+        buffer ||= ''.force_encoding(Encoding::ASCII_8BIT)
         remaining = length
 
         acquire_ownership :r
@@ -97,7 +97,7 @@ module Celluloid
       end
 
       def readpartial(length, buffer = nil)
-        buffer ||= ''
+        buffer ||= ''.force_encoding(Encoding::ASCII_8BIT)
 
         begin
           read_nonblock(length, buffer)

--- a/spec/celluloid/io/tcp_socket_spec.rb
+++ b/spec/celluloid/io/tcp_socket_spec.rb
@@ -45,10 +45,24 @@ describe Celluloid::IO::TCPSocket do
       end
     end
 
+    it "reads data in ASCII-8BIT encoding" do
+      with_connected_sockets do |subject, peer|
+        peer << payload
+        within_io_actor { subject.read(payload.size).encoding }.should eq Encoding::ASCII_8BIT
+      end
+    end
+
     it "reads partial data" do
       with_connected_sockets do |subject, peer|
         peer << payload * 2
         within_io_actor { subject.readpartial(payload.size) }.should eq payload
+      end
+    end
+
+    it "reads partial data in ASCII-8BIT encoding" do
+      with_connected_sockets do |subject, peer|
+        peer << payload * 2
+        within_io_actor { subject.readpartial(payload.size).encoding }.should eq Encoding::ASCII_8BIT
       end
     end
 


### PR DESCRIPTION
Hi,

IO#read and #readpartial are supposed to return a string in ASCII-8BIT encoding, whereas those methods of Celluloid::IO::TCPSocket return an US-ASCII string.
(See http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-read for details)

I ran across this issue while using RubyAMI library, which depends on Celluloid::IO. It parses strings generated by the #readpartial, and examines characters in the string one by one, using String#ord. But #ord raises error if the string is an US-ASCII one and the examined character is not in US-ASCII range (something like UTF-8 characters, for example).

This patch fixes this issue by forcing ASCII-8BIT encoding.
Could you check this out and merge it into your product?

Thank you in advance
