### PR TITLE
Dynamically delegate undelying socket methods

### DIFF
--- a/lib/celluloid/io/tcp_server.rb
+++ b/lib/celluloid/io/tcp_server.rb
@@ -4,11 +4,11 @@ module Celluloid
   module IO
     # TCPServer with combined blocking and evented support
     class TCPServer
-      extend Forwardable
-      def_delegators :@server, :listen, :sysaccept, :close, :closed?
 
       def initialize(hostname, port)
         @server = ::TCPServer.new(hostname, port)
+        self.extend SingleForwardable
+        eval("self.def_delegators :@server, :#{(@server.methods-self.methods).join(", :")}")
       end
 
       def accept
@@ -35,6 +35,7 @@ module Celluloid
         actor = Thread.current[:actor]
         actor && actor.mailbox.is_a?(Celluloid::IO::Mailbox)
       end
+
     end
   end
 end

--- a/lib/celluloid/io/udp_socket.rb
+++ b/lib/celluloid/io/udp_socket.rb
@@ -2,11 +2,12 @@ module Celluloid
   module IO
     # UDPSockets with combined blocking and evented support
     class UDPSocket
-      extend Forwardable
-      def_delegators :@socket, :bind, :send, :recvfrom_nonblock, :close, :closed?
 
       def initialize
         @socket = ::UDPSocket.new
+        # Delegate underlying socket methods to this class for better interoperability
+        self.extend SingleForwardable
+        eval("self.def_delegators :@socket, :#{(@socket.methods-self.methods).join(", :")}")
       end
 
       # Are we inside of a Celluloid::IO actor?


### PR DESCRIPTION
This commit reworks method delegation for TCPSocket, UDPSocket,
and TCPServer.

Previously, methods were statically delegated by the developer.
However, when using the Celluloid::IO sockets as drop-in
replacements for STDLib's sockets, methods are often called by
external components which are not accessible via the wrapper.
To remedy this, delegators are now called in an eval during the
init process providing access to all underlying socket methods
not currently defined for the wrapper object.
