### PR TITLE
Nonblocking TCPSocket specs should actually use a non-blocking TCPSocket

### DIFF
--- a/spec/celluloid/io/tcp_socket_spec.rb
+++ b/spec/celluloid/io/tcp_socket_spec.rb
@@ -19,81 +19,85 @@ describe Celluloid::IO::TCPSocket do
     end
 
     it "should be evented" do
-      with_connected_sockets do |subject|
-        within_io_actor { subject.evented? }.should be_true
+      with_connected_actor_sockets do |subject|
+        subject.wrap { @socket.evented? }.should be_true
       end
     end
 
     it "read complete payload when nil size is given to #read" do
-      with_connected_sockets do |subject, peer|
+      pending '#read is broken in non-blocking mode'
+      with_connected_actor_sockets do |subject, peer|
         peer << payload
-        within_io_actor { subject.read(nil) }.should eq payload
+        subject.wrap { @socket.read(nil) }.should eq payload
       end
     end
 
     it "read complete payload when no size is given to #read" do
-      with_connected_sockets do |subject, peer|
+      pending '#read is broken in non-blocking mode'
+      with_connected_actor_sockets do |subject, peer|
         peer << payload
-        within_io_actor { subject.read }.should eq payload
+        subject.wrap { @socket.read }.should eq payload
       end
     end
 
     it "reads data" do
-      with_connected_sockets do |subject, peer|
+      pending '#read is broken in non-blocking mode'
+      with_connected_actor_sockets do |subject, peer|
         peer << payload
-        within_io_actor { subject.read(payload.size) }.should eq payload
+        subject.wrap { @socket.read(payload.size) }.should eq payload
       end
     end
 
     it "reads data in ASCII-8BIT encoding" do
-      with_connected_sockets do |subject, peer|
+      pending '#read is broken in non-blocking mode'
+      with_connected_actor_sockets do |subject, peer|
         peer << payload
-        within_io_actor { subject.read(payload.size).encoding }.should eq Encoding::ASCII_8BIT
+        subject.wrap { @socket.read(payload.size).encoding }.should eq Encoding::ASCII_8BIT
       end
     end
 
     it "reads partial data" do
-      with_connected_sockets do |subject, peer|
+      with_connected_actor_sockets do |subject, peer|
         peer << payload * 2
-        within_io_actor { subject.readpartial(payload.size) }.should eq payload
+        subject.wrap { @socket.readpartial(payload.size) }.should eq payload
       end
     end
 
     it "reads partial data in ASCII-8BIT encoding" do
-      with_connected_sockets do |subject, peer|
+      with_connected_actor_sockets do |subject, peer|
         peer << payload * 2
-        within_io_actor { subject.readpartial(payload.size).encoding }.should eq Encoding::ASCII_8BIT
+        subject.wrap { @socket.readpartial(payload.size).encoding }.should eq Encoding::ASCII_8BIT
       end
     end
 
     it "writes data" do
-      with_connected_sockets do |subject, peer|
-        within_io_actor { subject << payload }
+      with_connected_actor_sockets do |subject, peer|
+        subject.wrap { @socket << payload }
         peer.read(payload.size).should eq payload
       end
     end
 
     it "raises Errno::ECONNREFUSED when the connection is refused" do
       expect {
-        within_io_actor { ::TCPSocket.new(example_addr, example_port) }
+        within_io_actor { TCPSocket.new(example_addr, example_port) }
       }.to raise_error(Errno::ECONNREFUSED)
     end
 
     it "raises EOFError when partial reading from a closed socket" do
-      with_connected_sockets do |subject, peer|
+      with_connected_actor_sockets do |subject, peer|
         peer.close
         expect {
-          within_io_actor { subject.readpartial(payload.size) }
+          subject.wrap { @socket.readpartial(payload.size) }
         }.to raise_error(EOFError)
       end
     end
 
     it "raises IOError when partial reading from a socket we closed" do
-      with_connected_sockets do |subject, peer|
+      with_connected_actor_sockets do |subject, peer|
         expect {
-          within_io_actor do
-            subject.close
-            subject.readpartial(payload.size)
+          subject.wrap do
+            @socket.close
+            @socket.readpartial(payload.size)
           end
         }.to raise_error(IOError)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,6 @@ end
 
 def with_connected_sockets
   with_tcp_server do |server|
-    # FIXME: client isn't actually a Celluloid::IO::TCPSocket yet
     client = ::TCPSocket.new(example_addr, example_port)
     peer = server.accept
 
@@ -57,6 +56,24 @@ def with_connected_sockets
     ensure
       begin
         client.close
+        peer.close
+      rescue
+      end
+    end
+  end
+end
+
+def with_connected_actor_sockets
+  with_tcp_server do |server|
+    client_actor = ExampleActor.new
+    client_actor.wrap { @socket = TCPSocket.new(example_addr, example_port) }
+    peer = server.accept
+
+    begin
+      yield client_actor, peer
+    ensure
+      begin
+        client_actor.wrap { @socket.close }
         peer.close
       rescue
       end


### PR DESCRIPTION
It seems the `TCPSocket` specs were using a blocking `TCPSocket` outside of an actor (https://github.com/celluloid/celluloid-io/blob/master/spec/spec_helper.rb#L51), and simply reading from it within an actor. This is an invalid test and does not cover this use case: https://github.com/celluloid/celluloid-io/blob/master/examples/echo_client.rb#L14

I have corrected the specs to use a non-blocking `Celluloid::IO::TCPSocket`. There are a couple of outstanding issues:
- `#read` appears to be broken and hangs indefinitely
- `#evented?` is undefined

I'm not 100% certain that the new specs are valid, so those need to be verified before we can classify the failures as genuine bugs. Additionally, I have not run anywhere other than CRuby 1.9.3 for now, and am focussing on getting that working before tackling JRuby/rbx/2.0.0 compat later.
