### PR TITLE
Create correct << method that returns self instead of total_written

### DIFF
--- a/lib/celluloid/io/common_methods.rb
+++ b/lib/celluloid/io/common_methods.rb
@@ -136,7 +136,11 @@ module Celluloid
 
         total_written
       end
-      alias_method :<<, :write
+      
+      def <<(string)
+        write string
+        self
+      end
     end
   end
 end


### PR DESCRIPTION
Consult http://rdoc.info/stdlib/core/IO#%3C%3C-instance_method vs. http://rdoc.info/stdlib/core/IO#write-instance_method
