### PR TITLE
add ssl accept support

### DIFF
--- a/lib/celluloid/io.rb
+++ b/lib/celluloid/io.rb
@@ -13,6 +13,7 @@ require 'celluloid/io/udp_socket'
 require 'celluloid/io/unix_server'
 require 'celluloid/io/unix_socket'
 
+require 'celluloid/io/ssl_server'
 require 'celluloid/io/ssl_socket'
 
 module Celluloid

--- a/lib/celluloid/io/ssl_server.rb
+++ b/lib/celluloid/io/ssl_server.rb
@@ -1,0 +1,36 @@
+require 'socket'
+
+module Celluloid
+  module IO
+    # SSLServer wraps a TCPServer to provide immediate SSL accept
+    class SSLServer
+      extend Forwardable
+      def_delegators :@tcp_server, :listen, :shutdown, :close, :closed?, :to_io, :evented?
+
+      attr_accessor :start_immediately
+      attr_reader :tcp_server
+
+      def initialize(server, ctx)
+        if server.is_a?(::TCPServer)
+          server = Celluloid::IO::TCPServer.from_ruby_server(server)
+        end
+        @tcp_server = server
+        @ctx = ctx
+        @start_immediately = true
+      end
+
+      def accept
+        sock = @tcp_server.accept
+        begin
+          ssl = Celluloid::IO::SSLSocket.new(sock, @ctx)
+          ssl.accept if @start_immediately
+          ssl
+        rescue SSLError
+          sock.close
+          raise
+        end
+      end
+    end
+  end
+end
+

--- a/lib/celluloid/io/ssl_socket.rb
+++ b/lib/celluloid/io/ssl_socket.rb
@@ -22,6 +22,17 @@ module Celluloid
         retry
       end
 
+      def accept
+        @socket.accept_nonblock
+        self
+      rescue ::IO::WaitReadable
+        wait_readable
+        retry
+      rescue ::IO::WaitWritable
+        wait_writable
+        retry
+      end
+
       def to_io; @socket; end
     end
   end

--- a/lib/celluloid/io/tcp_server.rb
+++ b/lib/celluloid/io/tcp_server.rb
@@ -35,6 +35,13 @@ module Celluloid
         actor = Thread.current[:celluloid_actor]
         actor && actor.mailbox.is_a?(Celluloid::IO::Mailbox)
       end
+
+      # Convert a Ruby TCPServer into a Celluloid::IO::TCPServer
+      def self.from_ruby_server(ruby_server)
+        server = allocate
+        server.instance_variable_set(:@server, ruby_server)
+        server
+      end
     end
   end
 end

--- a/spec/celluloid/io/ssl_server_spec.rb
+++ b/spec/celluloid/io/ssl_server_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe Celluloid::IO::SSLServer do
+  let(:client_cert) { OpenSSL::X509::Certificate.new fixture_dir.join("client.crt").read }
+  let(:client_key)  { OpenSSL::PKey::RSA.new fixture_dir.join("client.key").read }
+  let(:client_context) do
+    OpenSSL::SSL::SSLContext.new.tap do |context|
+      context.cert = client_cert
+      context.key  = client_key
+    end
+  end
+
+  let(:server_cert) { OpenSSL::X509::Certificate.new fixture_dir.join("server.crt").read }
+  let(:server_key)  { OpenSSL::PKey::RSA.new fixture_dir.join("server.key").read }
+  let(:server_context) do
+    OpenSSL::SSL::SSLContext.new.tap do |context|
+      context.cert = server_cert
+      context.key  = server_key
+    end
+  end
+
+  describe "#accept" do
+    let(:payload) { 'ohai' }
+
+    context "inside Celluloid::IO" do
+      it "should be evented" do
+        with_ssl_server do |subject|
+          within_io_actor { subject.evented? }.should be_true
+        end
+      end
+
+      it "accepts a connection and returns a Celluloid::IO::SSLSocket" do
+        with_ssl_server do |subject|
+          thread = Thread.new do
+            raw = TCPSocket.new(example_addr, example_ssl_port)
+            ssl = OpenSSL::SSL::SSLSocket.new(raw, client_context).connect
+          end
+          peer = within_io_actor { subject.accept }
+          peer.should be_a Celluloid::IO::SSLSocket
+
+          client = thread.value
+          client.write payload
+          peer.read(payload.size).should eq payload
+        end
+      end
+    end
+
+    context "outside Celluloid::IO" do
+      it "should be blocking" do
+        with_ssl_server do |subject|
+          subject.should_not be_evented
+        end
+      end
+
+      it "accepts a connection and returns a Celluloid::IO::SSLSocket" do
+        with_ssl_server do |subject|
+          thread = Thread.new do
+            raw = TCPSocket.new(example_addr, example_ssl_port)
+            ssl = OpenSSL::SSL::SSLSocket.new(raw, client_context).connect
+          end
+          peer = subject.accept
+          peer.should be_a Celluloid::IO::SSLSocket
+
+          client = thread.value
+          client.write payload
+          peer.read(payload.size).should eq payload
+        end
+      end
+    end
+  end
+
+  describe "#initialize" do
+    it "should auto-wrap a raw ::TCPServer" do
+      raw_server = ::TCPServer.new(example_addr, example_ssl_port)
+      with_ssl_server(raw_server) do |ssl_server|
+        ssl_server.tcp_server.class.should == Celluloid::IO::TCPServer
+      end
+    end
+  end
+
+  def with_ssl_server(raw_server = nil)
+    raw_server ||= Celluloid::IO::TCPServer.new(example_addr, example_ssl_port)
+    server = Celluloid::IO::SSLServer.new(raw_server, server_context)
+    begin
+      yield server
+    ensure
+      server.close
+    end
+  end
+end
+


### PR DESCRIPTION
Adds an #accept method to SSLSocket, upgrading the already-accepted TCP
socket to an SSL connection. This is the same API as OpenSSL::SSL::SSLSocket

Also adds a convenience Celluloid::IO::SSLServer class, with the same
API as the OpenSSL::SSL::SSLServer class, which wraps a TCPServer and
automatically upgrades accepted sockets to SSL before returning them.
