### PR TITLE
Add missing delegates for rack hijack in Reel

### DIFF
--- a/lib/celluloid/io/tcp_socket.rb
+++ b/lib/celluloid/io/tcp_socket.rb
@@ -7,7 +7,7 @@ module Celluloid
     class TCPSocket < Stream
       extend Forwardable
 
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :close, :closed?
+      def_delegators :@socket, :read_nonblock, :write_nonblock, :close, :close_read, :close_write, :closed?
       def_delegators :@socket, :addr, :peeraddr, :setsockopt
 
       # Open a TCP socket, yielding it to the given block and closing it


### PR DESCRIPTION
celluloid/reel#42 needs these methods. 
