### PR TITLE
Celluloid::IO breaks if tasks contend on both reads and writes simultaneously

### DIFF
--- a/lib/celluloid/io/reactor.rb
+++ b/lib/celluloid/io/reactor.rb
@@ -14,20 +14,25 @@ module Celluloid
 
       def initialize
         @selector = NIO::Selector.new
+        @monitors = {}
       end
 
       # Wait for the given IO object to become readable
       def wait_readable(io)
-        wait io, :r
+        wait io do |monitor|
+          monitor.wait_readable
+        end
       end
 
       # Wait for the given IO object to become writable
       def wait_writable(io)
-        wait io, :w
+        wait io do |monitor|
+          monitor.wait_writable
+        end
       end
 
       # Wait for the given IO operation to complete
-      def wait(io, set)
+      def wait(io)
         # zomg ugly type conversion :(
         unless io.is_a?(::IO) or io.is_a?(OpenSSL::SSL::SSLSocket)
           if io.respond_to? :to_io
@@ -39,21 +44,89 @@ module Celluloid
           raise TypeError, "can't convert #{io.class} into IO" unless io.is_a?(::IO)
         end
 
-        monitor = @selector.register(io, set)
-        monitor.value = Task.current
-        Task.suspend :iowait
+        unless monitor = @monitors[io]
+          monitor = Monitor.new(@selector, io)
+          @monitors[io] = monitor
+        end
+
+        yield monitor
       end
 
       # Run the reactor, waiting for events or wakeup signal
       def run_once(timeout = nil)
         @selector.select(timeout) do |monitor|
-          task = monitor.value
-          monitor.close
+          monitor.value.resume
+        end
+      end
 
-          if task.running?
-            task.resume
-          else
-            Logger.warn("reactor attempted to resume a dead task")
+      class Monitor
+        def initialize(selector, io)
+          @selector = selector
+          @io = io
+          @interests = {}
+        end
+
+        def wait_readable
+          wait :r
+        end
+
+        def wait_writable
+          wait :w
+        end
+
+        def wait(interest)
+          raise "Already waiting for #{interest.inspect}" if @interests.include?(interest)
+          @interests[interest] = Task.current
+          reregister
+          Task.suspend :iowait
+        end
+
+        def reregister
+          if @monitor
+            @monitor.close
+            @monitor = nil
+          end
+
+          if interests_symbol
+            @monitor = @selector.register(@io, interests_symbol)
+            @monitor.value = self
+          end
+        end
+
+        def interests_symbol
+          case @interests.keys
+          when [:r]
+            :r
+          when [:w]
+            :w
+          when [:r, :w]
+            :rw
+          end
+        end
+
+        def resume
+          raise "No monitor" unless @monitor
+
+          if @monitor.readable?
+            resume_for :r
+          end
+
+          if @monitor.writable?
+            resume_for :w
+          end
+
+          reregister
+        end
+
+        def resume_for(interest)
+          task = @interests.delete(interest)
+
+          if task
+            if task.running?
+              task.resume
+            else
+              raise "reactor attempted to resume a dead task"
+            end
           end
         end
       end


### PR DESCRIPTION
Hi,
streaming a rails application with ringleader, sometimes i have this exception:

```
 INFO 18:15:40.102628 | publisher_admin | 192.168.196.65 - - [28/Aug/2012 18:15:40] "GET %2Fassets%2Factive_admin-53e0270d3b7867040477c0e8a731159f.js HTTP/1.1" 206 503770 0.0018
 INFO 18:15:40.881735 | publisher_admin | 192.168.196.65 - - [28/Aug/2012 18:15:40] "GET /admin/recipes HTTP/1.1" 304 - 0.1884
 INFO 18:15:40.900777 | publisher_admin | 192.168.196.65 - - [28/Aug/2012 18:15:40] "GET %2Fassets%2Factive_admin-d6817fe924b0efe5bae0fcd2d891eef9.css HTTP/1.1" 304 - 0.0013
 INFO 18:15:40.901950 | publisher_admin | 192.168.196.65 - - [28/Aug/2012 18:15:40] "GET %2Fassets%2Factive_admin-53e0270d3b7867040477c0e8a731159f.js HTTP/1.1" 206 1 0.0008
ERROR 18:15:40.907013 | Ringleader::SocketProxy crashed!
ArgumentError: this IO is already registered with selector
/home/websvil/.rvm/gems/ruby-1.9.3-p194/gems/celluloid-io-0.11.0/lib/celluloid/io/reactor.rb:42:in `register'
/home/websvil/.rvm/gems/ruby-1.9.3-p194/gems/celluloid-io-0.11.0/lib/celluloid/io/reactor.rb:42:in `wait'
/home/websvil/.rvm/gems/ruby-1.9.3-p194/gems/celluloid-io-0.11.0/lib/celluloid/io/reactor.rb:26:in `wait_writable'
/home/websvil/.rvm/gems/ruby-1.9.3-p194/gems/celluloid-0.11.1/lib/celluloid/calls.rb:57:in `dispatch'
/home/websvil/.rvm/gems/ruby-1.9.3-p194/gems/celluloid-0.11.1/lib/celluloid/actor.rb:240:in `block in handle_message'
/home/websvil/.rvm/gems/ruby-1.9.3-p194/gems/celluloid-0.11.1/lib/celluloid/task.rb:45:in `block in initialize'
```

when in the same request is served the same file 2 times it give this problem. Can be an issue of ringleader or of celluloid-io?
