### PR TITLE
Fix TCPServer duck typing

### DIFF
--- a/lib/celluloid/io/tcp_server.rb
+++ b/lib/celluloid/io/tcp_server.rb
@@ -7,8 +7,12 @@ module Celluloid
       extend Forwardable
       def_delegators :@server, :listen, :sysaccept, :close, :closed?, :addr
 
-      def initialize(hostname, port)
-        @server = ::TCPServer.new(hostname, port)
+      def initialize(hostname_or_port, port=nil)
+        if(port.nil?)
+          @server = ::TCPServer.new(hostname_or_port)
+        else
+          @server = ::TCPServer.new(hostname_or_port, port)
+        end
       end
 
       def accept

--- a/spec/celluloid/io/tcp_server_spec.rb
+++ b/spec/celluloid/io/tcp_server_spec.rb
@@ -4,6 +4,10 @@ describe Celluloid::IO::TCPServer do
   describe "#accept" do
     let(:payload) { 'ohai' }
 
+    it "can be initialized without a host" do
+      expect{ server = Celluloid::IO::TCPServer.new(2000); server.close }.to_not raise_error
+    end
+
     context "inside Celluloid::IO" do
       it "should be evented" do
         with_tcp_server do |subject|


### PR DESCRIPTION
Ruby's TCPServer takes 1 or 2 arguments.  This makes
Celluloid::IO::TCPServer operate the same, so that it can be a drop-in
replacement in cases where the Ruby TCPServer's hostname is not
specified.  Fixes #67.
