### PR TITLE
Add #peeraddr delegator for SSLSocket

### DIFF
--- a/lib/celluloid/io/ssl_socket.rb
+++ b/lib/celluloid/io/ssl_socket.rb
@@ -7,7 +7,7 @@ module Celluloid
       extend Forwardable
 
       def_delegators :@socket, :read_nonblock, :write_nonblock, :close, :closed?,
-        :cert, :cipher, :client_ca, :peer_cert, :peer_cert_chain, :verify_result
+        :cert, :cipher, :client_ca, :peer_cert, :peer_cert_chain, :verify_result, :peeraddr
 
       def initialize(io, ctx = OpenSSL::SSL::SSLContext.new)
         super()

--- a/spec/celluloid/io/ssl_socket_spec.rb
+++ b/spec/celluloid/io/ssl_socket_spec.rb
@@ -59,6 +59,14 @@ describe Celluloid::IO::SSLSocket do
     end
   end
 
+  context "duck typing ::SSLSocket" do
+    it "responds to #peeraddr" do
+      with_ssl_sockets do |ssl_client, ssl_peer|
+        expect{ ssl_client.peeraddr }.to_not raise_error
+      end
+    end
+  end
+
   context "inside Celluloid::IO" do
     it "connects to SSL servers over TCP" do
       with_ssl_sockets do |ssl_client, ssl_peer|


### PR DESCRIPTION
This came up when I was reproducing the sample echo server defined in
ruby source here:
https://github.com/ruby/ruby/blob/trunk/sample/openssl/echo_svr.rb#L58
