### PR TITLE
Never shovel nil so you don't have to compact

### DIFF
--- a/lib/celluloid/io/dns_resolver.rb
+++ b/lib/celluloid/io/dns_resolver.rb
@@ -71,8 +71,7 @@ module Celluloid
         addrs = []
         # The answer might include IN::CNAME entries so filters them out
         # to include IN::A & IN::AAAA entries only.
-        response.each_answer { |name, ttl, value| addrs << (value.respond_to?(:address) ? value.address : nil) }
-        addrs.compact!
+        response.each_answer { |name, ttl, value| addrs << value.address if value.respond_to?(:address) }
 
         return if addrs.empty?
         return addrs.first if addrs.size == 1


### PR DESCRIPTION
Remove ternary so that you never shovel nil onto the addrs array, which removes the need to call #compact!. This gets rid of an extra step since we're not mapping.
