### PR TITLE
Add eof?/eof method as part of buffed IO method.

### DIFF
--- a/lib/celluloid/io/stream.rb
+++ b/lib/celluloid/io/stream.rb
@@ -312,6 +312,17 @@ module Celluloid
         sysclose
       end
 
+      # Check if the stream reached to EOF.
+      #
+      # IO#eof?/eof is a blocking method so wait_readable needs to be
+      # called until receive the first byte.
+      def eof?
+        sysread(0)
+
+        to_io.eof?
+      end
+      alias_method :eof, :eof?
+
       #######
       private
       #######

--- a/spec/celluloid/io/tcp_socket_spec.rb
+++ b/spec/celluloid/io/tcp_socket_spec.rb
@@ -79,6 +79,15 @@ describe Celluloid::IO::TCPSocket do
       }.to raise_error(Errno::ECONNREFUSED)
     end
 
+    it "blocks actor until eof? gets the first byte" do
+      with_connected_sockets do |subject, peer|
+        start = Time.now
+        Thread.new{ sleep 0.5; peer.close; }
+        within_io_actor { subject.eof? }
+        (Time.now - start).should > 0.5
+      end
+    end
+
     context "readpartial" do
       it "raises EOFError when reading from a closed socket" do
         with_connected_sockets do |subject, peer|

--- a/spec/celluloid/io/unix_socket_spec.rb
+++ b/spec/celluloid/io/unix_socket_spec.rb
@@ -92,6 +92,15 @@ describe Celluloid::IO::UNIXSocket do
         }.to raise_error(EOFError)
       end
     end
+
+    it "blocks actor until eof? gets the first byte" do
+      with_connected_unix_sockets do |subject, peer|
+        start = Time.now
+        Thread.new{ sleep 0.5; peer.close; }
+        within_io_actor { subject.eof? }
+        (Time.now - start).should > 0.5
+      end
+    end
   end
 
   context "outside Celluloid::IO" do


### PR DESCRIPTION
IO#eof?/eof is a blocking method according to the reference manual. so they are added to adapt the standard.

http://www.ruby-doc.org/core-2.0/IO.html#method-i-eof
