### PR TITLE
Add address family as optional UDPSocket constructor argument

### DIFF
--- a/lib/celluloid/io/udp_socket.rb
+++ b/lib/celluloid/io/udp_socket.rb
@@ -5,8 +5,8 @@ module Celluloid
       extend Forwardable
       def_delegators :@socket, :bind, :send, :recvfrom_nonblock, :close, :closed?
 
-      def initialize
-        @socket = ::UDPSocket.new
+      def initialize(address_family = ::Socket::AF_INET)
+        @socket = ::UDPSocket.new(address_family)
       end
 
       # Wait until the socket is readable


### PR DESCRIPTION
There was an issue reported (#78).

`Celluloid::IO::UDPSocket` wrapper does not accept any arguments to underlying `::UDPSocket`.

`::UDPSocket` has address family set by default to AF_INET. If you need to use IPv6, you need to specify `::Socket::AF_INET6` as an argument to `::UDPSocket` constructor, which is missing if you are using wrapper.
