### PR TITLE
Revert "Allow waiting for read and write simultaneously"

### DIFF
--- a/lib/celluloid/io/reactor.rb
+++ b/lib/celluloid/io/reactor.rb
@@ -14,25 +14,20 @@ module Celluloid
 
       def initialize
         @selector = NIO::Selector.new
-        @monitors = {}
       end
 
       # Wait for the given IO object to become readable
       def wait_readable(io)
-        wait io do |monitor|
-          monitor.wait_readable
-        end
+        wait io, :r
       end
 
       # Wait for the given IO object to become writable
       def wait_writable(io)
-        wait io do |monitor|
-          monitor.wait_writable
-        end
+        wait io, :w
       end
 
       # Wait for the given IO operation to complete
-      def wait(io)
+      def wait(io, set)
         # zomg ugly type conversion :(
         unless io.is_a?(::IO) or io.is_a?(OpenSSL::SSL::SSLSocket)
           if io.respond_to? :to_io
@@ -44,89 +39,21 @@ module Celluloid
           raise TypeError, "can't convert #{io.class} into IO" unless io.is_a?(::IO)
         end
 
-        unless monitor = @monitors[io]
-          monitor = Monitor.new(@selector, io)
-          @monitors[io] = monitor
-        end
-
-        yield monitor
+        monitor = @selector.register(io, set)
+        monitor.value = Task.current
+        Task.suspend :iowait
       end
 
       # Run the reactor, waiting for events or wakeup signal
       def run_once(timeout = nil)
         @selector.select(timeout) do |monitor|
-          monitor.value.resume
-        end
-      end
+          task = monitor.value
+          monitor.close
 
-      class Monitor
-        def initialize(selector, io)
-          @selector = selector
-          @io = io
-          @interests = {}
-        end
-
-        def wait_readable
-          wait :r
-        end
-
-        def wait_writable
-          wait :w
-        end
-
-        def wait(interest)
-          raise "Already waiting for #{interest.inspect}" if @interests.include?(interest)
-          @interests[interest] = Task.current
-          reregister
-          Task.suspend :iowait
-        end
-
-        def reregister
-          if @monitor
-            @monitor.close
-            @monitor = nil
-          end
-
-          if interests_symbol
-            @monitor = @selector.register(@io, interests_symbol)
-            @monitor.value = self
-          end
-        end
-
-        def interests_symbol
-          case @interests.keys
-          when [:r]
-            :r
-          when [:w]
-            :w
-          when [:r, :w]
-            :rw
-          end
-        end
-
-        def resume
-          raise "No monitor" unless @monitor
-
-          if @monitor.readable?
-            resume_for :r
-          end
-
-          if @monitor.writable?
-            resume_for :w
-          end
-
-          reregister
-        end
-
-        def resume_for(interest)
-          task = @interests.delete(interest)
-
-          if task
-            if task.running?
-              task.resume
-            else
-              raise "reactor attempted to resume a dead task"
-            end
+          if task.running?
+            task.resume
+          else
+            Logger.warn("reactor attempted to resume a dead task")
           end
         end
       end


### PR DESCRIPTION
I believe this should address #118, but is broken in the event that a descriptor simultaneously contends on both reads and writes

cc @halorgium @monolar 
