### PR TITLE
Fixed invalid Errno::EAGAIN handling in Stream#syswrite

### DIFF
--- a/lib/celluloid/io/stream.rb
+++ b/lib/celluloid/io/stream.rb
@@ -64,6 +64,9 @@ module Celluloid
               retry
             rescue EOFError
               return total_written
+            rescue Errno::EAGAIN
+              wait_writable
+              retry
             end
 
             total_written += written


### PR DESCRIPTION
Imaginary test:
- do_write is called with 300 bytes string 
- syswrite is called with 300 bytes string
- total_written is 0
- write_nonblock is called with 300 bytes string
- write_nonblock writes only 100 of them
- written and total_written are now  100
- write_nonblock is called with 200 bytes string
- write_nonblock writes only 100 of them
- written is now 100, total_written is now 200
- write_nonblock is called with 100 bytes string
- Errno::EAGAIN is thrown
- in do_write() we are retrying sys_write again with remaining 100 bytes
- **new** instance of syswrite is called with 100 bytes string
- **total_written is 0**
- write_nonblock is called with 100 bytes string
- write_nonblock writes 100 bytes
- written and total_written are now 100
- **syswrite returns result 100 instead of 300 to do_write**

Looking at FIXME in syswrite i think maybe all this code should be refactored but I wanted my fix to be as small as possible. Also I don't know how to implement unittest for this bug so it's up to you.
