### PR TITLE
removing exception check from monitor close

### DIFF
--- a/lib/celluloid/io/reactor.rb
+++ b/lib/celluloid/io/reactor.rb
@@ -49,7 +49,7 @@ module Celluloid
           # have woken up. However, in some cases, the monitor is already 
           # invalid, e.g. in the case that we are terminating. We catch this
           # case explicitly.
-          monitor.close unless Celluloid::Task::TerminatedError === $!
+          monitor.close
         end
       end
 


### PR DESCRIPTION
As soon as [this](https://github.com/celluloid/nio4r/pull/55) works. 