### PR TITLE
Delegate #post_connection_check on Celluloid::IO::SSLSocket

### DIFF
--- a/lib/celluloid/io/ssl_socket.rb
+++ b/lib/celluloid/io/ssl_socket.rb
@@ -6,8 +6,20 @@ module Celluloid
     class SSLSocket < Stream
       extend Forwardable
 
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :close, :closed?,
-        :cert, :cipher, :client_ca, :peer_cert, :peer_cert_chain, :verify_result, :peeraddr, :sync_close=
+      def_delegators :@socket,
+        :read_nonblock,
+        :write_nonblock,
+        :close,
+        :closed?,
+        :cert,
+        :cipher,
+        :client_ca,
+        :peeraddr,
+        :peer_cert,
+        :peer_cert_chain,
+        :post_connection_check,
+        :verify_result,
+        :sync_close=
 
       def initialize(io, ctx = OpenSSL::SSL::SSLContext.new)
         super()


### PR DESCRIPTION
This method is needed to perform hostname verification, without which MitM
attacks are possible using any cert rooted in the local truststore.