### PR TITLE
Handle MRI's Errno::EALREADY in connect_nonblock. Fixes #138

### DIFF
--- a/lib/celluloid/io/tcp_socket.rb
+++ b/lib/celluloid/io/tcp_socket.rb
@@ -80,7 +80,9 @@ module Celluloid
 
         begin
           @socket.connect_nonblock Socket.sockaddr_in(remote_port, @addr.to_s)
-        rescue Errno::EINPROGRESS
+        rescue Errno::EINPROGRESS, Errno::EALREADY
+          # JRuby raises EINPROGRESS, MRI raises EALREADY
+
           wait_writable
 
           # HAX: for some reason we need to finish_connect ourselves on JRuby


### PR DESCRIPTION
In certain high-load situations in RubyDNS (thousands of connections), it
has been observed that `Socket#connect_nonblock` sometimes fails with
`Errno::EALREADY`: a connection is already in progress for the specified
socket. In this case I believe it is prudent that we wait for the socket to
become writable and then attempt to `connect_nonblock` again, at which
point the connection should either fail or give `Errno::EISCONN`.