### PR TITLE
Stream#close is not called in subclasses

### DIFF
--- a/lib/celluloid/io/ssl_socket.rb
+++ b/lib/celluloid/io/ssl_socket.rb
@@ -9,7 +9,6 @@ module Celluloid
       def_delegators :@socket,
                      :read_nonblock,
                      :write_nonblock,
-                     :close,
                      :closed?,
                      :cert,
                      :cipher,

--- a/lib/celluloid/io/stream.rb
+++ b/lib/celluloid/io/stream.rb
@@ -309,7 +309,7 @@ module Celluloid
       # Closes the stream and flushes any unwritten data.
       def close
         flush rescue nil
-        sysclose
+        to_io.close
       end
 
       #######

--- a/lib/celluloid/io/tcp_socket.rb
+++ b/lib/celluloid/io/tcp_socket.rb
@@ -7,7 +7,7 @@ module Celluloid
     class TCPSocket < Stream
       extend Forwardable
 
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :close, :close_read, :close_write, :closed?
+      def_delegators :@socket, :read_nonblock, :write_nonblock, :close_read, :close_write, :closed?
       def_delegators :@socket, :addr, :peeraddr, :setsockopt, :getsockname
 
       # Open a TCP socket, yielding it to the given block and closing it

--- a/lib/celluloid/io/unix_socket.rb
+++ b/lib/celluloid/io/unix_socket.rb
@@ -6,7 +6,7 @@ module Celluloid
     class UNIXSocket < Stream
       extend Forwardable
 
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :close, :closed?, :readline, :puts, :addr
+      def_delegators :@socket, :read_nonblock, :write_nonblock, :closed?, :readline, :puts, :addr
 
       # Open a UNIX connection.
       def self.open(socket_path, &block)

--- a/spec/celluloid/io/tcp_socket_spec.rb
+++ b/spec/celluloid/io/tcp_socket_spec.rb
@@ -181,6 +181,20 @@ RSpec.describe Celluloid::IO::TCPSocket, library: :IO do
         end
       end
     end
+
+    context "close" do
+
+      it "flushes remaining data" do
+        with_connected_sockets(example_port) do |subject, peer|
+          subject.sync = false
+          within_io_actor { subject << payload }
+          expect{ peer.read_nonblock payload.length }.to raise_exception ::IO::WaitReadable
+          within_io_actor { subject.close }
+          expect(peer.read).to eq payload
+        end
+      end
+
+    end
   end
 
   context "outside Celluloid::IO" do


### PR DESCRIPTION
Hi

I wondered why Stream#close is actually never called in the specs ( see coveralls ) although several sockets are closed. Turned out that all subclasses forward their close method directly to the internal socket and therefore bypass flushing the write buffer. Moreover the Stream#close method doesn't work at all because no subclass defines a sysclose method.

Cheers'
Hannes