### PR TITLE
UNIXSocket: don't delegate #readline and #puts

### DIFF
--- a/lib/celluloid/io/unix_socket.rb
+++ b/lib/celluloid/io/unix_socket.rb
@@ -6,7 +6,7 @@ module Celluloid
     class UNIXSocket < Stream
       extend Forwardable
 
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :closed?, :readline, :puts, :addr
+      def_delegators :@socket, :read_nonblock, :write_nonblock, :closed?, :addr
 
       # Open a UNIX connection.
       def self.open(socket_path, &block)

--- a/spec/celluloid/io/unix_socket_spec.rb
+++ b/spec/celluloid/io/unix_socket_spec.rb
@@ -171,4 +171,33 @@ RSpec.describe Celluloid::IO::UNIXSocket, library: :IO do
       end
     end
   end
+
+  context 'puts' do
+    it 'uses the write buffer' do
+      with_connected_unix_sockets do |subject, peer|
+        subject.sync = false
+        subject << "a"
+        subject.puts "b"
+        subject << "c"
+        subject.flush
+        subject.close
+        expect(peer.read).to eq "ab\nc"
+      end
+    end
+  end
+
+  context 'readline' do
+    it 'uses the read buffer' do
+      with_connected_unix_sockets do |subject, peer|
+        peer << "xline one\nline two\n"
+        subject.getc # read one character to fill buffer
+        Timeout::timeout(1){
+          # this will block if the buffer is not used
+          expect(subject.readline).to eq "line one\n"
+          expect(subject.readline).to eq "line two\n"
+        }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Hi there

This is pretty much the same problem as #157. Delegating these two methods prevents them from using the internal buffers and therefore may lead to blocking IO and disordered bytes.

Cheers'
Hannes