### PR TITLE
Use a common super class for all socket wrappers

### DIFF
--- a/lib/celluloid/io.rb
+++ b/lib/celluloid/io.rb
@@ -4,6 +4,7 @@ require "celluloid"
 require "celluloid/io/dns_resolver"
 require "celluloid/io/mailbox"
 require "celluloid/io/reactor"
+require "celluloid/io/socket"
 require "celluloid/io/stream"
 
 require "celluloid/io/tcp_server"

--- a/lib/celluloid/io/socket.rb
+++ b/lib/celluloid/io/socket.rb
@@ -1,0 +1,80 @@
+module Celluloid
+  module IO
+    # Base class for all classes that wrap a ruby socket.
+    # @abstract
+    class Socket
+      extend Forwardable
+
+      def_delegators :@socket, :close, :close_read, :close_write, :closed?
+      def_delegators :@socket, :read_nonblock, :write_nonblock
+      def_delegators :@socket, :addr, :getsockopt, :setsockopt, :getsockname, :fcntl
+
+      # @param socket [BasicSocket, OpenSSL::SSL::SSLSocket]
+      def initialize( socket )
+        case( socket )
+        when ::BasicSocket, OpenSSL::SSL::SSLSocket
+          @socket = socket
+        else
+          raise ArgumentError, "expected a socket, got #{socket.inspect}"
+        end
+      end
+
+      # Returns the wrapped socket.
+      # @return [BasicSocket, OpenSSL::SSL::SSLSocket]
+      def to_io
+        @socket
+      end
+
+      # Compatibility
+      Constants = ::Socket::Constants
+      include Constants
+
+      # Celluloid::IO:Socket.new behaves like Socket.new for compatibility.
+      # This is is not problematic since Celluloid::IO::Socket is abstract.
+      # To instantiate a socket use one of its subclasses.
+      def self.new(*args)
+        if self == Celluloid::IO::Socket
+          return ::Socket.new(*args)
+        else
+          super
+        end
+      end
+
+      # Tries to convert the given ruby socket into a subclass of GenericSocket.
+      # @param socket
+      # @return [SSLSocket, TCPServer, TCPSocket, UDPSocket, UNIXServer, UNIXSocket]
+      # @return [nil] if the socket can't be converted
+      def self.try_convert( socket, convert_io = true )
+        case socket
+        when Celluloid::IO::Socket, Celluloid::IO::SSLServer then
+          socket
+        when ::TCPServer then
+          TCPServer.new(socket)
+        when ::TCPSocket then
+          TCPSocket.new(socket)
+        when ::UDPSocket then
+          UDPSocket.new(socket)
+        when ::UNIXServer then
+          UNIXServer.new(socket)
+        when ::UNIXSocket then
+          UNIXSocket.new(socket)
+        when OpenSSL::SSL::SSLServer
+          SSLServer.new(socket.to_io, socket.instance_variable_get(:@ctx))
+        when OpenSSL::SSL::SSLSocket
+          SSLSocket.new(socket)
+        else
+          if convert_io
+            return try_convert( IO.try_convert(socket), false )
+          end
+          nil
+        end
+      end
+
+      class << self
+        extend Forwardable
+        def_delegators '::Socket', *(::Socket.methods - self.methods - [:try_convert])
+      end
+
+    end
+  end
+end

--- a/lib/celluloid/io/ssl_server.rb
+++ b/lib/celluloid/io/ssl_server.rb
@@ -11,10 +11,7 @@ module Celluloid
       attr_reader :tcp_server
 
       def initialize(server, ctx)
-        if server.is_a?(::TCPServer)
-          server = Celluloid::IO::TCPServer.from_ruby_server(server)
-        end
-        @tcp_server = server
+        @tcp_server = Socket.try_convert(server)
         @ctx = ctx
         @start_immediately = true
       end

--- a/lib/celluloid/io/stream.rb
+++ b/lib/celluloid/io/stream.rb
@@ -8,7 +8,7 @@
 module Celluloid
   module IO
     # Base class of all streams in Celluloid::IO
-    class Stream
+    class Stream < Socket
       include Enumerable
 
       # The "sync mode" of the stream
@@ -16,7 +16,8 @@ module Celluloid
       # See IO#sync for full details.
       attr_accessor :sync
 
-      def initialize
+      def initialize( socket )
+        super
         @eof  = false
         @sync = true
         @read_buffer = ''.force_encoding(Encoding::ASCII_8BIT)
@@ -309,7 +310,7 @@ module Celluloid
       # Closes the stream and flushes any unwritten data.
       def close
         flush rescue nil
-        to_io.close
+        super
       end
 
       #######

--- a/lib/celluloid/io/tcp_server.rb
+++ b/lib/celluloid/io/tcp_server.rb
@@ -3,36 +3,49 @@ require 'socket'
 module Celluloid
   module IO
     # TCPServer with combined blocking and evented support
-    class TCPServer
+    class TCPServer < Socket
       extend Forwardable
-      def_delegators :@server, :listen, :sysaccept, :close, :closed?, :addr, :setsockopt
+      def_delegators :to_io, :listen, :sysaccept, :addr
 
-      def initialize(hostname_or_port, port = nil)
-        if port.nil?
-          @server = ::TCPServer.new(hostname_or_port)
+      # @overload initialize( port )
+      #   Opens a tcp server on the given port.
+      #   @param port [Numeric]
+      #
+      # @overload initialize( hostname, port )
+      #   Opens a tcp server on the given port and interface.
+      #   @param hostname [String]
+      #   @param port [Numeric]
+      #
+      # @overload initialize( socket )
+      #   Wraps an already existing tcp server instance.
+      #   @param socket [::TCPServer]
+      def initialize(*args)
+        if args.first.kind_of? ::BasicSocket
+          # socket
+          socket = args.first
+          fail ArgumentError, "wrong number of arguments (#{args.size} for 1)" if args.size != 1
+          fail ArgumentError, "wrong kind of socket (#{socket.class} for TCPServer)" unless socket.kind_of? ::TCPServer
+          super( socket )
         else
-          @server = ::TCPServer.new(hostname_or_port, port)
+          super( ::TCPServer.new(*args) )
         end
       end
 
+      # @return [TCPSocket]
       def accept
-        Celluloid::IO.wait_readable(@server)
+        Celluloid::IO.wait_readable(to_io)
         accept_nonblock
       end
 
+      # @return [TCPSocket]
       def accept_nonblock
-        Celluloid::IO::TCPSocket.new(@server.accept_nonblock)
-      end
-
-      def to_io
-        @server
+        Celluloid::IO::TCPSocket.new(to_io.accept_nonblock)
       end
 
       # Convert a Ruby TCPServer into a Celluloid::IO::TCPServer
+      # @deprecated Use .new instead.
       def self.from_ruby_server(ruby_server)
-        server = allocate
-        server.instance_variable_set(:@server, ruby_server)
-        server
+        new(ruby_server)
       end
     end
   end

--- a/lib/celluloid/io/tcp_socket.rb
+++ b/lib/celluloid/io/tcp_socket.rb
@@ -7,8 +7,7 @@ module Celluloid
     class TCPSocket < Stream
       extend Forwardable
 
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :close_read, :close_write, :closed?
-      def_delegators :@socket, :addr, :peeraddr, :setsockopt, :getsockname
+      def_delegators :to_io, :peeraddr
 
       # Open a TCP socket, yielding it to the given block and closing it
       # automatically when done (if a block is given)
@@ -25,78 +24,34 @@ module Celluloid
 
       # Convert a Ruby TCPSocket into a Celluloid::IO::TCPSocket
       # DEPRECATED: to be removed in a future release
+      # @deprecated Use {Celluloid::IO::TCPSocket#new} instead.
       def self.from_ruby_socket(ruby_socket)
         new(ruby_socket)
       end
 
-      # Opens a TCP connection to remote_host on remote_port. If local_host
-      # and local_port are specified, then those parameters are used on the
-      # local end to establish the connection.
-      def initialize(remote_host, remote_port = nil, local_host = nil, local_port = nil)
-        super()
-
-        # Allow users to pass in a Ruby TCPSocket directly
-        if remote_host.is_a? ::TCPSocket
-          @addr = nil
-          @socket = remote_host
-          return
-        elsif remote_port.nil?
-          fail ArgumentError, "wrong number of arguments (1 for 2)"
+      # @overload initialize( remote_host, remote_port = nil, local_host = nil, local_port = nil )
+      #   Opens a TCP connection to remote_host on remote_port. If local_host
+      #   and local_port are specified, then those parameters are used on the
+      #   local end to establish the connection.
+      #   @param remote_host [String, Resolv::IPv4, Resolv::IPv6]
+      #   @param remote_port [Numeric]
+      #   @param local_host  [String]
+      #   @param local_port  [Numeric]
+      #
+      # @overload initialize( socket )
+      #   Wraps an already existing tcp socket.
+      #   @param socket [::TCPSocket]
+      #
+      def initialize(*args)
+        if args.first.kind_of? ::BasicSocket
+          # socket
+          socket = args.first
+          fail ArgumentError, "wrong number of arguments (#{args.size} for 1)" if args.size != 1
+          fail ArgumentError, "wrong kind of socket (#{socket.class} for TCPSocket)" unless socket.kind_of? ::TCPSocket
+          super( socket )
+        else
+          super( create_socket(*args) )
         end
-
-        # Is it an IPv4 address?
-        begin
-          @addr = Resolv::IPv4.create(remote_host)
-        rescue ArgumentError
-        end
-
-        # Guess it's not IPv4! Is it IPv6?
-        unless @addr
-          begin
-            @addr = Resolv::IPv6.create(remote_host)
-          rescue ArgumentError
-          end
-        end
-
-        # Guess it's not an IP address, so let's try DNS
-        unless @addr
-          addrs = Array(DNSResolver.new.resolve(remote_host))
-          fail Resolv::ResolvError, "DNS result has no information for #{remote_host}" if addrs.empty?
-
-          # Pseudorandom round-robin DNS support :/
-          @addr = addrs[rand(addrs.size)]
-        end
-
-        case @addr
-        when Resolv::IPv4
-          family = Socket::AF_INET
-        when Resolv::IPv6
-          family = Socket::AF_INET6
-        else fail ArgumentError, "unsupported address class: #{@addr.class}"
-        end
-
-        @socket = Socket.new(family, Socket::SOCK_STREAM, 0)
-        @socket.bind Addrinfo.tcp(local_host, local_port) if local_host
-
-        begin
-          @socket.connect_nonblock Socket.sockaddr_in(remote_port, @addr.to_s)
-        rescue Errno::EINPROGRESS, Errno::EALREADY
-          # JRuby raises EINPROGRESS, MRI raises EALREADY
-
-          wait_writable
-
-          # HAX: for some reason we need to finish_connect ourselves on JRuby
-          # This logic is unnecessary but JRuby still throws Errno::EINPROGRESS
-          # if we retry the non-blocking connect instead of just finishing it
-          retry unless RUBY_PLATFORM == "java" && @socket.to_channel.finish_connect
-        rescue Errno::EISCONN
-          # We're now connected! Yay exceptions for flow control
-          # NOTE: This is the approach the Ruby stdlib docs suggest ;_;
-        end
-      end
-
-      def to_io
-        @socket
       end
 
       # Receives a message
@@ -110,6 +65,73 @@ module Celluloid
         fail NotImplementedError, "dest_sockaddr not supported" if dest_sockaddr
         fail NotImplementedError, "flags not supported" unless flags.zero?
         write(msg)
+      end
+
+      # @return [Resolv::IPv4, Resolv::IPv6]
+      def addr
+        socket = to_io
+        ra = socket.remote_address
+        if ra.ipv4?
+          return Resolv::IPv4.create(ra.ip_address)
+        elsif ra.ipv6?
+          return Resolv::IPv6.create(ra.ip_address)
+        else
+          raise ArgumentError, "not an ip socket: #{socket.inspect}"
+        end
+      end
+    private
+
+      def create_socket(remote_host, remote_port = nil, local_host = nil, local_port = nil)
+        # Is it an IPv4 address?
+        begin
+          addr = Resolv::IPv4.create(remote_host)
+        rescue ArgumentError
+        end
+
+        # Guess it's not IPv4! Is it IPv6?
+        unless addr
+          begin
+            addr = Resolv::IPv6.create(remote_host)
+          rescue ArgumentError
+          end
+        end
+
+        # Guess it's not an IP address, so let's try DNS
+        unless addr
+          addrs = Array(DNSResolver.new.resolve(remote_host))
+          fail Resolv::ResolvError, "DNS result has no information for #{remote_host}" if addrs.empty?
+
+          # Pseudorandom round-robin DNS support :/
+          addr = addrs[rand(addrs.size)]
+        end
+
+        case addr
+        when Resolv::IPv4
+          family = Socket::AF_INET
+        when Resolv::IPv6
+          family = Socket::AF_INET6
+        else fail ArgumentError, "unsupported address class: #{addr.class}"
+        end
+
+        socket = Socket.new(family, Socket::SOCK_STREAM, 0)
+        socket.bind Addrinfo.tcp(local_host, local_port) if local_host
+
+        begin
+          socket.connect_nonblock Socket.sockaddr_in(remote_port, addr.to_s)
+        rescue Errno::EINPROGRESS, Errno::EALREADY
+          # JRuby raises EINPROGRESS, MRI raises EALREADY
+          Celluloid::IO.wait_writable(socket)
+
+          # HAX: for some reason we need to finish_connect ourselves on JRuby
+          # This logic is unnecessary but JRuby still throws Errno::EINPROGRESS
+          # if we retry the non-blocking connect instead of just finishing it
+          retry unless RUBY_PLATFORM == "java" && socket.to_channel.finish_connect
+        rescue Errno::EISCONN
+          # We're now connected! Yay exceptions for flow control
+          # NOTE: This is the approach the Ruby stdlib docs suggest ;_;
+        end
+
+        return socket
       end
     end
   end

--- a/lib/celluloid/io/udp_socket.rb
+++ b/lib/celluloid/io/udp_socket.rb
@@ -1,12 +1,27 @@
 module Celluloid
   module IO
     # UDPSockets with combined blocking and evented support
-    class UDPSocket
+    class UDPSocket < Socket
       extend Forwardable
-      def_delegators :@socket, :addr, :bind, :connect, :send, :recvfrom_nonblock, :close, :closed?
+      def_delegators :to_io, :bind, :connect, :send, :recvfrom_nonblock
 
-      def initialize(address_family = ::Socket::AF_INET)
-        @socket = ::UDPSocket.new(address_family)
+      # @overload initialize( address_family )
+      #   Opens a new udp socket using address_family.
+      #   @param address_family [Numeric]
+      #
+      # @overload initialize( socket )
+      #   Wraps an already existing udp socket.
+      #   @param socket [::UDPSocket]
+      def initialize(*args)
+        if args.first.kind_of? ::BasicSocket
+          # socket
+          socket = args.first
+          fail ArgumentError, "wrong number of arguments (#{args.size} for 1)" if args.size != 1
+          fail ArgumentError, "wrong kind of socket (#{socket.class} for UDPSocket)" unless socket.kind_of? ::UDPSocket
+          super( socket )
+        else
+          super( ::UDPSocket.new(*args) )
+        end
       end
 
       # Wait until the socket is readable
@@ -18,11 +33,12 @@ module Celluloid
       # protocol-specific address information of the sender.
       def recvfrom(maxlen, flags = nil)
         begin
-          if @socket.respond_to? :recvfrom_nonblock
-            @socket.recvfrom_nonblock(maxlen, flags)
+          socket = to_io
+          if socket.respond_to? :recvfrom_nonblock
+            socket.recvfrom_nonblock(maxlen, flags)
           else
             # FIXME: hax for JRuby
-            @socket.recvfrom(maxlen, flags)
+            socket.recvfrom(maxlen, flags)
           end
         rescue ::IO::WaitReadable
           wait_readable
@@ -30,7 +46,6 @@ module Celluloid
         end
       end
 
-      def to_io; @socket; end
     end
   end
 end

--- a/lib/celluloid/io/unix_server.rb
+++ b/lib/celluloid/io/unix_server.rb
@@ -3,40 +3,48 @@ require 'socket'
 module Celluloid
   module IO
     # UNIXServer with combined blocking and evented support
-    class UNIXServer
+    class UNIXServer < Socket
       extend Forwardable
-      def_delegators :@server, :listen, :sysaccept, :close, :closed?
+      def_delegators :to_io, :listen, :sysaccept
 
       def self.open(socket_path)
         self.new(socket_path)
       end
 
-      def initialize(socket_path)
-        begin
-          @server = ::UNIXServer.new(socket_path)
-        rescue => ex
-          # Translate the EADDRINUSE jRuby exception.
-          raise unless RUBY_PLATFORM == 'java'
-          if ex.class.name == "IOError" && # Won't agree to .is_a?(IOError)
-             ex.message.include?("in use")
-            raise Errno::EADDRINUSE.new(ex.message)
+      # @overload initialize( socket_path )
+      #   @param socket_path [String]
+      #
+      # @overload initialize( socket )
+      #   @param socket [::UNIXServer]
+      def initialize(socket)
+        if socket.kind_of? ::BasicSocket
+          # socket
+          fail ArgumentError, "wrong kind of socket (#{socket.class} for UNIXServer)" unless socket.kind_of? ::UNIXServer
+          super( socket )
+        else
+          begin
+            super( ::UNIXServer.new(socket) )
+          rescue => ex
+            # Translate the EADDRINUSE jRuby exception.
+            raise unless RUBY_PLATFORM == 'java'
+            if ex.class.name == "IOError" && # Won't agree to .is_a?(IOError)
+               ex.message.include?("in use")
+              raise Errno::EADDRINUSE.new(ex.message)
+            end
+            raise
           end
-          raise
         end
       end
 
       def accept
-        Celluloid::IO.wait_readable(@server)
+        Celluloid::IO.wait_readable(to_io)
         accept_nonblock
       end
 
       def accept_nonblock
-        Celluloid::IO::UNIXSocket.new(@server.accept_nonblock)
+        Celluloid::IO::UNIXSocket.new(to_io.accept_nonblock)
       end
 
-      def to_io
-        @server
-      end
     end
   end
 end

--- a/lib/celluloid/io/unix_socket.rb
+++ b/lib/celluloid/io/unix_socket.rb
@@ -4,10 +4,6 @@ module Celluloid
   module IO
     # UNIXSocket with combined blocking and evented support
     class UNIXSocket < Stream
-      extend Forwardable
-
-      def_delegators :@socket, :read_nonblock, :write_nonblock, :closed?, :addr
-
       # Open a UNIX connection.
       def self.open(socket_path, &block)
         new(socket_path, &block)
@@ -15,31 +11,27 @@ module Celluloid
 
       # Convert a Ruby UNIXSocket into a Celluloid::IO::UNIXSocket
       # DEPRECATED: to be removed in a future release
+      # @deprecated use .new instead
       def self.from_ruby_socket(ruby_socket)
         new(ruby_socket)
       end
 
       # Open a UNIX connection.
       def initialize(socket_path, &block)
-        super()
-
         # Allow users to pass in a Ruby UNIXSocket directly
         if socket_path.is_a? ::UNIXSocket
-          @socket = socket_path
+          super( socket_path )
           return
         end
 
         # FIXME: not doing non-blocking connect
-        @socket = if block
-                    ::UNIXSocket.open(socket_path, &block)
-                  else
-                    ::UNIXSocket.new(socket_path)
+        if block
+          super ::UNIXSocket.open(socket_path, &block)
+        else
+          super ::UNIXSocket.new(socket_path)
         end
       end
 
-      def to_io
-        @socket
-      end
     end
   end
 end

--- a/spec/celluloid/io/socket_spec.rb
+++ b/spec/celluloid/io/socket_spec.rb
@@ -1,0 +1,173 @@
+require "spec_helper"
+
+RSpec.describe Celluloid::IO::Socket, library: :IO do
+  let(:logger) { Specs::FakeLogger.current }
+  let(:example_port) { assign_port }
+
+  context '.try_convert' do
+
+    subject{ described_class.try_convert(socket) }
+
+    after(:each) do
+      if subject.respond_to? :close
+        subject.close
+      else
+        socket.close if socket.respond_to? :close
+      end
+    end
+
+    context 'with a Celluloid Socket' do
+      let(:socket){ Celluloid::IO::UDPSocket.new }
+
+      it 'returns given socket' do
+        expect(subject).to be socket
+      end
+    end
+
+    context 'with a ::TCPServer' do
+      let(:socket){ ::TCPServer.new(example_port) }
+
+      it 'creates a Celluloid::IO::TCPServer' do
+        expect(subject).to be_a Celluloid::IO::TCPServer
+      end
+    end
+
+    context 'with a ::TCPSocket' do
+      let!(:server){
+        ::TCPServer.new example_addr, example_port
+      }
+      after(:each){
+        server.close
+      }
+
+      let(:socket){
+        ::TCPSocket.new example_addr, example_port
+      }
+
+      it 'creates a Celluloid::IO::TCPSocket' do
+        expect(subject).to be_a Celluloid::IO::TCPSocket
+      end
+    end
+
+    context 'with a ::UDPSocket' do
+      let(:socket){ ::UDPSocket.new }
+
+      it 'creates a Celluloid::IO::UDPServer' do
+        expect(subject).to be_a Celluloid::IO::UDPSocket
+      end
+    end
+
+    context 'with a ::UNIXServer' do
+      let(:socket){ ::UNIXServer.new(example_unix_sock) }
+
+      it 'creates a Celluloid::IO::UNIXServer' do
+        expect(subject).to be_a Celluloid::IO::UNIXServer
+      end
+    end
+
+    context 'with a ::UNIXSocket' do
+      let!(:server){
+        ::UNIXServer.new(example_unix_sock)
+      }
+      after(:each){
+        server.close
+      }
+
+      let(:socket){
+        ::UNIXSocket.new example_unix_sock
+      }
+
+      it 'creates a Celluloid::IO::UNIXSocket' do
+        expect(subject).to be_a Celluloid::IO::UNIXSocket
+      end
+    end
+
+    context 'with an OpenSSL::SSL::SSLServer' do
+      let(:socket){
+        OpenSSL::SSL::SSLServer.new(::TCPServer.new(example_addr, example_port), OpenSSL::SSL::SSLContext.new)
+      }
+
+      it 'creates a Celluloid::IO::SSLServer' do
+        expect(subject).to be_a Celluloid::IO::SSLServer
+      end
+    end
+
+    context 'with an OpenSSL::SSL::SSLSocket' do
+      let!(:server){
+        OpenSSL::SSL::SSLServer.new(::TCPServer.new(example_addr, example_port), OpenSSL::SSL::SSLContext.new)
+      }
+      after(:each){
+        server.close
+      }
+
+      let(:socket){
+        OpenSSL::SSL::SSLSocket.new(::TCPSocket.new(example_addr, example_port))
+      }
+
+     it 'creates a Celluloid::IO::SSLSocket' do
+        expect(subject).to be_a Celluloid::IO::SSLSocket
+      end
+    end
+
+    context 'with an object responding to #to_io' do
+      let(:real){
+        ::UDPSocket.new
+      }
+
+      let(:socket){
+        proxy = double(:socket)
+        allow(proxy).to receive(:to_io){ real }
+        allow(proxy).to receive(:close){ real.close }
+        proxy
+      }
+
+      it 'creates a celluloid socket' do
+        expect(subject).to be_a described_class
+      end
+
+      it 'uses the returned IO' do
+        expect(subject.to_io).to be socket.to_io
+      end
+    end
+
+    context 'with a simple object' do
+      let(:socket){ Object.new }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  context 'compatibility with ::Socket' do
+
+    context '.new' do
+      it "creates basic sockets" do
+        socket = Celluloid::IO::Socket.new( Celluloid::IO::Socket::AF_INET, Celluloid::IO::Socket::SOCK_STREAM, 0 )
+        expect( socket ).to be_a ::Socket
+        socket.close
+      end
+    end
+
+    context '.pair' do
+      it "creates basic sockets" do
+        a,b = Celluloid::IO::Socket.pair( Celluloid::IO::Socket::AF_UNIX, Celluloid::IO::Socket::SOCK_DGRAM, 0)
+        expect( a ).to be_a ::Socket
+        expect( b ).to be_a ::Socket
+        a.close
+        b.close
+      end
+    end
+
+    context '.for_fd' do
+      it "creates basic sockets" do
+        socket = Celluloid::IO::Socket.new( Celluloid::IO::Socket::AF_INET, Celluloid::IO::Socket::SOCK_STREAM, 0 )
+        copy = Celluloid::IO::Socket.for_fd( socket.fileno )
+        expect( copy ).to be_a ::Socket
+        copy.close
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is my approach on the proposed solution for #129

The new superclass is called Celluloid::IO::Socket and essentialy
deduplicates all #to_io methods and many delegates. This allows all
socket wrappers to be created from a raw ruby socket using their default
initializer or the new C::IO::Socket.try_convert method.

I've added some methods for backward compatibility so that code like this doesn't break:
```ruby
class MyClass
  include Celluloid::IO
  def my_method
    Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
  end
end
```

Cheers'
Hannes