### PR TITLE
Support Ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - rbx-2
   - jruby
+  - 2.3.0
   - 2.2.2
   - 2.2.0
   - 2.1.4

--- a/lib/celluloid/io/udp_socket.rb
+++ b/lib/celluloid/io/udp_socket.rb
@@ -16,7 +16,7 @@ module Celluloid
       # MSG_ options. The first element of the results, mesg, is the data
       # received. The second element, sender_addrinfo, contains
       # protocol-specific address information of the sender.
-      def recvfrom(maxlen, flags = nil)
+      def recvfrom(maxlen, flags = 0)
         begin
           if @socket.respond_to? :recvfrom_nonblock
             @socket.recvfrom_nonblock(maxlen, flags)


### PR DESCRIPTION
In Ruby 2.3.0, `UDPSocket#recvfrom`'s `flags` doesn't allow `nil`.
It should be Numeric value.

So I specified this default value to the same value as `UDPSocket#recvfrom`'s.