### PR TITLE
Nonblock without exception

### DIFF
--- a/spec/celluloid/io/actor_spec.rb
+++ b/spec/celluloid/io/actor_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Celluloid::IO do
+RSpec.describe Celluloid::IO do
   it_behaves_like "a Celluloid Actor", Celluloid::IO
 end

--- a/spec/celluloid/io/dns_resolver_spec.rb
+++ b/spec/celluloid/io/dns_resolver_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::DNSResolver do
+RSpec.describe Celluloid::IO::DNSResolver do
   describe '#resolve' do
     it 'resolves hostnames' do
       resolver = Celluloid::IO::DNSResolver.new

--- a/spec/celluloid/io/mailbox_spec.rb
+++ b/spec/celluloid/io/mailbox_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Celluloid::IO::Mailbox do
+RSpec.describe Celluloid::IO::Mailbox do
   it_behaves_like "a Celluloid Mailbox"
 end

--- a/spec/celluloid/io/ssl_server_spec.rb
+++ b/spec/celluloid/io/ssl_server_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::SSLServer do
+RSpec.describe Celluloid::IO::SSLServer do
   let(:client_cert) { OpenSSL::X509::Certificate.new fixture_dir.join("client.crt").read }
   let(:client_key)  { OpenSSL::PKey::RSA.new fixture_dir.join("client.key").read }
   let(:client_context) do

--- a/spec/celluloid/io/ssl_socket_spec.rb
+++ b/spec/celluloid/io/ssl_socket_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'openssl'
 
-describe Celluloid::IO::SSLSocket do
+RSpec.describe Celluloid::IO::SSLSocket do
   let(:request)  { 'ping' }
   let(:response) { 'pong' }
 

--- a/spec/celluloid/io/tcp_server_spec.rb
+++ b/spec/celluloid/io/tcp_server_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::TCPServer do
+RSpec.describe Celluloid::IO::TCPServer do
   describe "#accept" do
     let(:payload) { 'ohai' }
 

--- a/spec/celluloid/io/tcp_socket_spec.rb
+++ b/spec/celluloid/io/tcp_socket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::TCPSocket do
+RSpec.describe Celluloid::IO::TCPSocket do
   let(:payload) { 'ohai' }
 
   context "inside Celluloid::IO" do

--- a/spec/celluloid/io/udp_socket_spec.rb
+++ b/spec/celluloid/io/udp_socket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::UDPSocket do
+RSpec.describe Celluloid::IO::UDPSocket do
   let(:payload) { 'ohai' }
   subject do
     Celluloid::IO::UDPSocket.new.tap do |sock|

--- a/spec/celluloid/io/unix_server_spec.rb
+++ b/spec/celluloid/io/unix_server_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::UNIXServer do
+RSpec.describe Celluloid::IO::UNIXServer do
   describe "#accept" do
     before do
       pending "JRuby support" if defined?(JRUBY_VERSION)

--- a/spec/celluloid/io/unix_socket_spec.rb
+++ b/spec/celluloid/io/unix_socket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO::UNIXSocket do
+RSpec.describe Celluloid::IO::UNIXSocket do
   before do
     pending "JRuby support" if defined?(JRUBY_VERSION)
   end

--- a/spec/celluloid/io_spec.rb
+++ b/spec/celluloid/io_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::IO do
+RSpec.describe Celluloid::IO do
   context "copy_stream" do
     let(:host) { "127.0.0.1" }
     let(:port) { 23456 }


### PR DESCRIPTION
Related to #139 .

Should boost performance, as exception handling is a quite expensive VM operation. 

Left support for ruby 2.0.0, although the ball is on someone else to drop it. 