### PR TITLE
Adding support for io/wait and wait_readable/writable API, which matc…

### DIFF
--- a/lib/celluloid/io/socket.rb
+++ b/lib/celluloid/io/socket.rb
@@ -70,6 +70,18 @@ module Celluloid
         end
       end
 
+      # io/wait API, it belongs here as it is extended on all IOs
+
+      # Wait until the current object is readable
+      def wait_readable(*args)
+        Celluloid::IO.wait_readable(self, *args)
+      end
+
+      # Wait until the current object is writable
+      def wait_writable(*args)
+        Celluloid::IO.wait_writable(self, *args)
+      end
+
       class << self
         extend Forwardable
         def_delegators '::Socket', *(::Socket.methods - self.methods - [:try_convert])

--- a/lib/celluloid/io/stream.rb
+++ b/lib/celluloid/io/stream.rb
@@ -27,12 +27,6 @@ module Celluloid
         @write_latch = Latch.new
       end
 
-      # Wait until the current object is readable
-      def wait_readable; Celluloid::IO.wait_readable(self); end
-
-      # Wait until the current object is writable
-      def wait_writable; Celluloid::IO.wait_writable(self); end
-
       # System read via the nonblocking subsystem
       def sysread(length = nil, buffer = nil)
         buffer ||= ''.force_encoding(Encoding::ASCII_8BIT)

--- a/lib/celluloid/io/tcp_server.rb
+++ b/lib/celluloid/io/tcp_server.rb
@@ -33,12 +33,12 @@ module Celluloid
 
       # @return [TCPSocket]
       def accept
-        Celluloid::IO.wait_readable(to_io)
         accept_nonblock
       end
 
       # @return [TCPSocket]
       def accept_nonblock
+        Celluloid::IO.wait_readable(to_io)
         Celluloid::IO::TCPSocket.new(to_io.accept_nonblock)
       end
 

--- a/lib/celluloid/io/udp_socket.rb
+++ b/lib/celluloid/io/udp_socket.rb
@@ -24,9 +24,6 @@ module Celluloid
         end
       end
 
-      # Wait until the socket is readable
-      def wait_readable; Celluloid::IO.wait_readable(self); end
-
       # Receives up to maxlen bytes from socket. flags is zero or more of the
       # MSG_ options. The first element of the results, mesg, is the data
       # received. The second element, sender_addrinfo, contains


### PR DESCRIPTION
…hes the Celluloid IO Socket APIs, excepted for the signature; Added support for timeout parameter, which will bubble down to Celluloid.timeout; falling back to Kernel.select when the io does not define the method (SSLSockets) or when the implementation in the ruby VMs is buggy (TCPServer and UNIXServer#wait_readable/writable are throwing Errno::EINVAL, weird)